### PR TITLE
Add $XmlLogPath parameter to allow for specifying a custom location for the temporary WinSCP XML log file.

### DIFF
--- a/WinSCP/Public/New-WinSCPSession.ps1
+++ b/WinSCP/Public/New-WinSCPSession.ps1
@@ -58,7 +58,10 @@
             }
         })]
         [String]
-        $SessionLogPath = $null
+        $SessionLogPath = $null,
+
+        [String]
+        $XmlLogPath = $null
     )
 
     begin {
@@ -102,6 +105,10 @@
                     $_
                 )
             }
+        }
+
+        if($XmlLogPath -ne $null){
+            $session.XmlLogPath = $XmlLogPath
         }
 
         try {

--- a/WinSCP/Public/New-WinSCPSession.ps1
+++ b/WinSCP/Public/New-WinSCPSession.ps1
@@ -61,7 +61,10 @@
         $SessionLogPath = $null,
 
         [String]
-        $XmlLogPath = $null
+        $XmlLogPath = $null,
+
+        [Boolean]
+        $XmlLogPreserve = $false
     )
 
     begin {

--- a/WinSCP/Public/New-WinSCPSession.ps1
+++ b/WinSCP/Public/New-WinSCPSession.ps1
@@ -60,6 +60,14 @@
         [String]
         $SessionLogPath = $null,
 
+        [Parameter()]
+        [ValidateScript({
+            if (Test-Path -Path (Split-Path -Path $_ -Parent)) {
+                return $true
+            } else {
+                throw "Path not found $(Split-Path -Path $_ -Parent)."
+            }
+        })]
         [String]
         $XmlLogPath = $null,
 

--- a/WinSCP/Public/New-WinSCPSession.ps1
+++ b/WinSCP/Public/New-WinSCPSession.ps1
@@ -107,10 +107,6 @@
             }
         }
 
-        if($XmlLogPath -ne $null){
-            $session.XmlLogPath = $XmlLogPath
-        }
-
         try {
             # Open the WinSCP.Session object using the WinSCP.SessionOptions object.
             $session.Open(


### PR DESCRIPTION
Added $XmlLogPath parameter to allow for specifying a custom location for the XML Log Path. This is a workaround for issues I am encountering where the default Windows temp path cannot be written to.